### PR TITLE
CL-3390: Course page image rendering issues on stage

### DIFF
--- a/lib/cachedir.js
+++ b/lib/cachedir.js
@@ -19,7 +19,7 @@ var Cachedir = function(config) {
 
 /**
  * generates a path from filename string.
- * the path is generated using the first 4 carachters of the filename
+ * the path is generated using the first 4 characters of the filename
  *
  * e.g.: this_is_a_filename.txt will become - <cache_dir>/t/h/i/s/this_is_a_filename.txt
  * where cache_dir, is the configured dir for caches. The returned callback will have 2 params:
@@ -55,6 +55,29 @@ Cachedir.prototype.download = function(url, force, callback) {
   md5(url, function(hash) {
     // get cached path
     self.get_cached_path(hash, function(output_file, exists) {
+
+      // Helper function to unlink any partial or corrupt output file we may have generated
+      // as part of a failed download or pipe to disk. Unlink async in the background which
+      // was the existing behavior, but capture and log any errors.
+      function cleanup() {
+        fs.unlink(output_file, function(err) {
+          if (err) {
+            log.error('Failed to unlink output file: ' + output_file);
+          } else {
+            log.verbose('Unlinked output file: ' + output_file);
+          }
+        });
+      }
+
+      // Helper function to avoid duplicate callback invocations.
+      var done = false;
+      function finish(err, outputFile) {
+        if (!done) {
+          done = true;
+          callback(err, outputFile);
+        }
+      }
+
       if (exists && !force) {
         // see if the downloaded file is ready to be serverd
         fs.open(output_file, 'r', function(err, fd) {
@@ -64,33 +87,31 @@ Cachedir.prototype.download = function(url, force, callback) {
               if (err) {
                 log.trace('couldn\'t lock ' + output_file + ', seems like the file is still being downloaded (' + err.message + ')');
                 return setTimeout(function() {
-                  self.download(url, force, callback);
+                  self.download(url, force, finish);
                 }, 0); // retry
               }
 
               log.verbose('the file "' + path.basename(output_file) + '" is already downloaded, skipping...');
-              callback(null, output_file);
+              finish(null, output_file);
             });
           });
         });
       } else {
         mkdirp(path.dirname(output_file), function(err) {
-          if (err) return callback(new Error(err));
+          if (err) return finish(new Error(err));
 
           // prepare the writer for piping
-          var writer = fs.createWriteStream(output_file, {
-              flags: 'a'
-            }),
-            r;
+          var writer = fs.createWriteStream(output_file);
 
           writer.on('open', function(fd) {
+            log.trace('opened stream for output file=' + output_file + ', fd=' + fd);
             // try to aquire EXCLUSIVE lock (cause we're writing to file)
             fs.flock(fd, 'exnb', function(err) {
               if (err) {
                 log.trace('couldn\'t lock ' + output_file + ', while downloading (' + err.message + ')');
                 return fs.close(fd, function() {
                   process.nextTick(function() {
-                    self.download(url, force, callback);
+                    self.download(url, force, finish);
                   }); // retry
                 });
               }
@@ -99,22 +120,23 @@ Cachedir.prototype.download = function(url, force, callback) {
               log.verbose('locked ' + output_file + ', starting downloading...');
 
               // get the data
-              r = request(url),
+              var r = request(url);
 
-                // do not continue on download errors
-                r.on('error', function(err) {
-                  return fs.close(fd, function() {
-                    fs.unlink(output_file);
-                    callback(err);
-                  });
+              // do not continue on download errors
+              r.on('error', function(err) {
+                return fs.close(fd, function() {
+                  cleanup();
+                  finish(err);
                 });
+              });
 
               r.on('response', function(res) {
                 // do not continue if http status is not ok (200)
+                log.info('@response: output file=' + output_file + ', status code=' + res.statusCode);
                 if (res.statusCode !== 200) {
                   return fs.close(fd, function() {
-                    fs.unlink(output_file);
-                    callback(new Error('couldn\'t download from: ' + url + ', http error: ' + res.statusCode));
+                    cleanup();
+                    finish(new Error('couldn\'t download from: ' + url + ', http error: ' + res.statusCode));
                   });
                 }
 
@@ -124,10 +146,24 @@ Cachedir.prototype.download = function(url, force, callback) {
             });
           });
 
-          writer.on('close', function() {
-            log.info('downloaded file from: ' + url + ', saved to: ' + output_file);
-            callback(null, output_file);
+          // Just for diagnostics.
+          writer.on('finish', function() {
+            log.info('@finish: output=' + output_file);
           });
+
+          // Success.
+          writer.on('close', function() {
+            log.info('@close - downloaded file from: ' + url + ', saved to: ' + output_file);
+            finish(null, output_file);
+          });
+
+          // Failure.
+          // This event was added between 0.10.0 and 0.10.40: https://nodejs.org/docs/v0.10.40/api/stream.html#stream_event_error_1
+          writer.on('error', function(err) {
+            log.error('@error: output=' + output_file + ', error=' + err);
+            finish(err);
+          })
+
         });
       }
     });

--- a/lib/cachedir.js
+++ b/lib/cachedir.js
@@ -161,6 +161,7 @@ Cachedir.prototype.download = function(url, force, callback) {
           // This event was added between 0.10.0 and 0.10.40: https://nodejs.org/docs/v0.10.40/api/stream.html#stream_event_error_1
           writer.on('error', function(err) {
             log.error('@error: output=' + output_file + ', error=' + err);
+            cleanup();
             finish(err);
           })
 


### PR DESCRIPTION
Fix broken behavior of appending a forced download file onto the tail of whatever has already been downloaded, use w instead of a for mode. Also add logging and an error handler for the writablestream and guard against multiple invocations of the client-supplied callback