### PR TITLE
CL-5710: Twitter not pulling course page images again

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -31,9 +31,11 @@ app.use(express.logger({
   format: access_log_format
 }));
 app.use(express.responseTime());
+// Originally, server set cache header to maxAge of 2419200000 in ms (28 days); reduce to 1 minute
+// so that robots.txt and other resources can be refreshed on a tighter cycle.
 app.use(express.static(public_dir, {
-  maxAge: 2419200000
-})); // in ms (28 days)
+  maxAge: 1000 * 60 * 1
+}));
 app.use(oldapi()); // process old api
 app.use(imgresizer);
 


### PR DESCRIPTION
reduce http cache maxAge for static assets served from local public folder, e.g. robots.txt