### PR TITLE
CL-4237 change processing default quality from 92 to 60

### DIFF
--- a/lib/imgresizer.js
+++ b/lib/imgresizer.js
@@ -152,7 +152,7 @@ function processImage(params, method, callback) {
     // normalize query params
     var width = params.w || '';
     var height = params.h || '';
-    var quality = params.q || 60; // 92 was the default but based on CL-4237 we decided to reduce the quality of jpeg compression for faster load
+    var quality = params.q || 69; // 92 was the default but based on CL-4237 we decided to reduce the quality of jpeg compression for faster load
     var filename = sprintf('%s_%s_q%s_%sx%s', path.basename(downloaded_image), method, quality, width, height); // <img-name>_<method>_q<quality>_<width>x<height>
 
     imgcache.get_cached_path(filename, function(dest, exists) {

--- a/lib/imgresizer.js
+++ b/lib/imgresizer.js
@@ -152,7 +152,7 @@ function processImage(params, method, callback) {
     // normalize query params
     var width = params.w || '';
     var height = params.h || '';
-    var quality = params.q || 92; // 92 is the default anyway
+    var quality = params.q || 60; // 92 was the default but based on CL-4237 we decided to reduce the quality of jpeg compression for faster load
     var filename = sprintf('%s_%s_q%s_%sx%s', path.basename(downloaded_image), method, quality, width, height); // <img-name>_<method>_q<quality>_<width>x<height>
 
     imgcache.get_cached_path(filename, function(dest, exists) {


### PR DESCRIPTION
In some cases the image process by mkimage-server ended up being having a larger file-size than the origin image for the same dimension. This is due to the quality of the jpeg compression. if the original image was already compressed with the lower compression rate than 92 (previous default compression rate for mkimage-server the new rendered image will have a larger file size) then mkimage-server will render a large outpout file.

This PR just reduce the jpeg compression rate to 60, the image quality difference is barely noticeable at a normal zoom.

Here is an example:
**Original Image (463k)**
![60](https://cloud.githubusercontent.com/assets/3515824/20769093/6fb01ebe-b6f5-11e6-9de4-97f8475bac8a.jpg)

**Compression Rate 92 (197k)**
![92](https://cloud.githubusercontent.com/assets/3515824/20769094/6fb63a1a-b6f5-11e6-8c29-d9e5e605336a.jpg)
<img width="1019" alt="zoom-92" src="https://cloud.githubusercontent.com/assets/3515824/20769451/cb248ed2-b6f6-11e6-8d0e-23337a720c3c.png">

**Compression Rate 60 (71k)**
![original](https://cloud.githubusercontent.com/assets/3515824/20769095/6fb8058e-b6f5-11e6-82db-e39aaa30ef5e.jpg)
<img width="1012" alt="zoom-60" src="https://cloud.githubusercontent.com/assets/3515824/20769442/c5eced60-b6f6-11e6-992e-f12a562528cc.png">


cc @jimmybyrum @sehod