### PR TITLE
changed cache header from one day to one year

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "verbose": true,
     "access_log_format": "default",
     "allowed_hosts": ["*.creativelive.com"],
-    "cache_max_age": 86400,
+    "cache_max_age": 31536000,
     "ssl": {
       "listen": false
     }


### PR DESCRIPTION
Changing Cache-Control header to max-age=31536000 from max-age=86400 (one day to one year)

@jimmybyrum @commanderklaus 